### PR TITLE
fix error

### DIFF
--- a/Runtime/WXRuntimeExtDef.cs
+++ b/Runtime/WXRuntimeExtDef.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 
 namespace WeChatWASM
 {
+#if UNITY_EDITOR
     public class WXRuntimeExtDef
     {
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
@@ -129,5 +130,5 @@ namespace WeChatWASM
             });
         }
     }
-    
+#endif
 }


### PR DESCRIPTION
Assets\WX-WASM-SDK-V2\Runtime\WXRuntimeExtDef.cs(20,13): error CS0103: The name 'WXRuntimeExtEnvDef' does not exist in the current context