### PR TITLE
fix: use PLATFORM_WEIXINMINIGAME instead of WEIXINMINIGAME for webglDir path

### DIFF
--- a/Editor/WXConvertCore.cs
+++ b/Editor/WXConvertCore.cs
@@ -287,7 +287,7 @@ namespace WeChatWASM
                     else
                     {
                         var rootPath = Directory.GetParent(Application.dataPath).FullName;
-                        string webglDir = WXExtEnvDef.GETDEF("WEIXINMINIGAME") ? "WeixinMiniGame" : "WebGL";
+                        string webglDir = WXExtEnvDef.GETDEF("PLATFORM_WEIXINMINIGAME") ? "WeixinMiniGame" : "WebGL";
 #if PLATFORM_PLAYABLEADS
                         webglDir = "PlayableAds";
 #endif


### PR DESCRIPTION
## Problem

When exporting to WeChat Mini Game from **Unity** (not Tuanjie engine), the build fails with:

```
preprocessSymbols failed. 
System.IO.DirectoryNotFoundException: Could not find a part of the path 
".../Library/Bee/artifacts/WeixinMiniGame/build/debug_WebGL_wasm/build.js.symbols"
```

## Root Cause

In `WXConvertCore.cs` line 290, the code uses `WXExtEnvDef.GETDEF("WEIXINMINIGAME")` to determine the `webglDir`:

```csharp
string webglDir = WXExtEnvDef.GETDEF("WEIXINMINIGAME") ? "WeixinMiniGame" : "WebGL";
```

`WEIXINMINIGAME` is only defined in **Tuanjie engine**, not in Unity. This causes the `webglDir` to always resolve to "WebGL" on Unity, but the actual Bee artifacts path uses "WeixinMiniGame" when building for the WeChat Mini Game platform.

The correct macro should be `PLATFORM_WEIXINMINIGAME`, which is properly defined in Unity when targeting the WeChat Mini Game platform.

## Fix

Change `WEIXINMINIGAME` to `PLATFORM_WEIXINMINIGAME` so that Unity builds can correctly resolve the Bee artifacts directory path.

Fixes #62